### PR TITLE
Unbias the uniform distribution

### DIFF
--- a/uniform.go
+++ b/uniform.go
@@ -12,7 +12,7 @@ type Uniform struct {
 }
 
 // Jitter the duration by drawing from a uniform distribution
-// over the range [Min, d). Returns Min if d <= Min
+// over the range [Min, d). Panics if d <= Min
 func (u Uniform) Jitter(d time.Duration) time.Duration {
 	drawUniform := rand.Int63n
 	if u.Source != nil {
@@ -21,7 +21,7 @@ func (u Uniform) Jitter(d time.Duration) time.Duration {
 
 	delta := d - u.Min
 	if delta <= 0 {
-		return u.Min
+		panic("duration must exceed min")
 	}
 	return u.Min + time.Duration(drawUniform(int64(delta)))
 }

--- a/uniform.go
+++ b/uniform.go
@@ -12,12 +12,16 @@ type Uniform struct {
 }
 
 // Jitter the duration by drawing from a uniform distribution
+// over the range [Min, d). Returns Min if d <= Min
 func (u Uniform) Jitter(d time.Duration) time.Duration {
 	drawUniform := rand.Int63n
 	if u.Source != nil {
 		drawUniform = u.Source.Int63n
 	}
 
-	d = time.Duration(drawUniform(int64(d)))
-	return max(d, u.Min)
+	delta := d - u.Min
+	if delta <= 0 {
+		return u.Min
+	}
+	return u.Min + time.Duration(drawUniform(int64(delta)))
 }


### PR DESCRIPTION
As discussed in #4, this change prevents the the uniform distribution from being unexpectedly biased towards Min. 
I also added a check to ensure d > Min, otherwise returning the Min, to ensure `rand.Int63n` won't panic if that's not the case. If you'd rather not have this preventative check, I can remove it.