### PR TITLE
Update go.mod path to support v2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Jitterbug has no external dependencies, has a stable API, and is production-read
 ## Installation
 
 ```bash
-go get -u github.com/lthibault/jitterbug
+go get -u github.com/lthibault/jitterbug/v2
 ```
 
 ## Usage

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/lthibault/jitterbug
+module github.com/lthibault/jitterbug/v2
 
 go 1.14


### PR DESCRIPTION
Fixes https://github.com/lthibault/jitterbug/issues/6.

@mikeyrcamp This is my first time having to deal with a `v2` in a go module.  Could you please sanity-check this PR?  Have I overlooked anything?  Thanks!

--------

⚠️ Note to self:  Don't forget to push a `v2.2.2` tag after merging.